### PR TITLE
Heroku worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node app.js
+worker: node app.js

--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 var https = require("https");
 var Geckoboard = require('geckoboard-push');
-var port = 5000;
 
 ///////////////////////////////
 // Your personal settings /////
@@ -148,18 +147,3 @@ function refresh() {
 }
 
 	refresh();
-
-
-https.createServer(function (request, response) {
-}).listen(process.env.PORT || 5000);
-
-
-
-
-
-
-
-
-
-
-

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A ChartMogul library for Geckoboard",
   "main": "request-node.js",
   "dependencies": {
-    "express": "^4.13.4",
     "geckoboard-push": "^2.0.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
Hey Bill, thanks for sharing your Chartmogul+Stripe->Geckoboard app! I noticed this bit that saves some work.

A Heroku Node.js `web` process needs to respond to the process.env.PORT
or it will crash. This changes the app to use the `worker` process type
that doesn't need to listen for HTTP/S requests.

https://devcenter.heroku.com/articles/procfile#declaring-process-types
